### PR TITLE
Remapping bools again + buttons resetting bugfix

### DIFF
--- a/WindowsFormsApp1/ElevatorEmulator.cs
+++ b/WindowsFormsApp1/ElevatorEmulator.cs
@@ -1078,108 +1078,108 @@ namespace WindowsFormsApp1
         ///  - 0-31 binary bools [52-83(?)]
         /// </summary>
         /// 
-        private const int SyncBool_Initialized = 0;
-        private const int SyncBool_Elevator0working = 1;
-        private const int SyncBool_Elevator1working = 2;
-        private const int SyncBool_Elevator2working = 3;
-        private const int SyncBool_Elevator0open = 4;
-        private const int SyncBool_Elevator1open = 5;
-        private const int SyncBool_Elevator2open = 6;
-        private const int SyncBool_Elevator0idle = 7;
-        private const int SyncBool_Elevator1idle = 8;
-        private const int SyncBool_Elevator2idle = 9;
-        private const int SyncBool_Elevator0goingUp = 10;
-        private const int SyncBool_Elevator1goingUp = 11;
-        private const int SyncBool_Elevator2goingUp = 12;
+        private const int SyncBoolReq_BellOn = 0;
+        private const int SyncBool_Elevator0open = 1;
+        private const int SyncBool_Elevator1open = 2;
+        private const int SyncBool_Elevator2open = 3;
+        private const int SyncBool_Elevator0idle = 4;
+        private const int SyncBool_Elevator1idle = 5;
+        private const int SyncBool_Elevator2idle = 6;
+        private const int SyncBool_Elevator0goingUp = 7;
+        private const int SyncBool_Elevator1goingUp = 8;
+        private const int SyncBool_Elevator2goingUp = 9;
         /// <summary>
         /// Sync-data positions for elevator call up buttons
         /// </summary>
-        private const int SyncBoolReq_ElevatorCalledUp_0 = 13;
-        private const int SyncBoolReq_ElevatorCalledUp_1 = 14;
-        private const int SyncBoolReq_ElevatorCalledUp_2 = 15;
-        private const int SyncBoolReq_ElevatorCalledUp_3 = 16;
-        private const int SyncBoolReq_ElevatorCalledUp_4 = 17;
-        private const int SyncBoolReq_ElevatorCalledUp_5 = 18;
-        private const int SyncBoolReq_ElevatorCalledUp_6 = 19;
-        private const int SyncBoolReq_ElevatorCalledUp_7 = 20;
-        private const int SyncBoolReq_ElevatorCalledUp_8 = 21;
-        private const int SyncBoolReq_ElevatorCalledUp_9 = 22;
-        private const int SyncBoolReq_ElevatorCalledUp_10 = 23;
-        private const int SyncBoolReq_ElevatorCalledUp_11 = 24;
-        private const int SyncBoolReq_ElevatorCalledUp_12 = 25;
-        private const int SyncBoolReq_ElevatorCalledUp_13 = 26;
+        private const int SyncBoolReq_ElevatorCalledUp_0 = 10;
+        private const int SyncBoolReq_ElevatorCalledUp_1 = 11;
+        private const int SyncBoolReq_ElevatorCalledUp_2 = 12;
+        private const int SyncBoolReq_ElevatorCalledUp_3 = 13;
+        private const int SyncBoolReq_ElevatorCalledUp_4 = 14;
+        private const int SyncBoolReq_ElevatorCalledUp_5 = 15;
+        private const int SyncBoolReq_ElevatorCalledUp_6 = 16;
+        private const int SyncBoolReq_ElevatorCalledUp_7 = 17;
+        private const int SyncBoolReq_ElevatorCalledUp_8 = 18;
+        private const int SyncBoolReq_ElevatorCalledUp_9 = 19;
+        private const int SyncBoolReq_ElevatorCalledUp_10 = 20;
+        private const int SyncBoolReq_ElevatorCalledUp_11 = 21;
+        private const int SyncBoolReq_ElevatorCalledUp_12 = 22;
+        private const int SyncBoolReq_ElevatorCalledUp_13 = 23;
         /// <summary>
         /// Sync-data positions for elevator call down buttons
         /// </summary>
-        private const int SyncBoolReq_ElevatorCalledDown_0 = 27;
-        private const int SyncBoolReq_ElevatorCalledDown_1 = 28;
-        private const int SyncBoolReq_ElevatorCalledDown_2 = 29;
-        private const int SyncBoolReq_ElevatorCalledDown_3 = 30;
-        private const int SyncBoolReq_ElevatorCalledDown_4 = 31;
-        private const int SyncBoolReq_ElevatorCalledDown_5 = 32;
-        private const int SyncBoolReq_ElevatorCalledDown_6 = 33;
-        private const int SyncBoolReq_ElevatorCalledDown_7 = 34;
-        private const int SyncBoolReq_ElevatorCalledDown_8 = 35;
-        private const int SyncBoolReq_ElevatorCalledDown_9 = 36;
-        private const int SyncBoolReq_ElevatorCalledDown_10 = 37;
-        private const int SyncBoolReq_ElevatorCalledDown_11 = 38;
-        private const int SyncBoolReq_ElevatorCalledDown_12 = 39;
-        private const int SyncBoolReq_ElevatorCalledDown_13 = 40;
+        private const int SyncBoolReq_ElevatorCalledDown_0 = 24;
+        private const int SyncBoolReq_ElevatorCalledDown_1 = 25;
+        private const int SyncBoolReq_ElevatorCalledDown_2 = 26;
+        private const int SyncBoolReq_ElevatorCalledDown_3 = 27;
+        private const int SyncBoolReq_ElevatorCalledDown_4 = 28;
+        private const int SyncBoolReq_ElevatorCalledDown_5 = 29;
+        private const int SyncBoolReq_ElevatorCalledDown_6 = 30;
+        private const int SyncBoolReq_ElevatorCalledDown_7 = 31;
+        private const int SyncBoolReq_ElevatorCalledDown_8 = 32;
+        private const int SyncBoolReq_ElevatorCalledDown_9 = 33;
+        private const int SyncBoolReq_ElevatorCalledDown_10 = 34;
+        private const int SyncBoolReq_ElevatorCalledDown_11 = 35;
+        private const int SyncBoolReq_ElevatorCalledDown_12 = 36;
+        private const int SyncBoolReq_ElevatorCalledDown_13 = 37;
         /// <summary>
         /// Sync-data positions for internal elevator 0 buttons
         /// </summary>
-        private const int SyncBoolReq_Elevator0CalledToFloor_0 = 41;
-        private const int SyncBoolReq_Elevator0CalledToFloor_1 = 42;
-        private const int SyncBoolReq_Elevator0CalledToFloor_2 = 43;
-        private const int SyncBoolReq_Elevator0CalledToFloor_3 = 44;
-        private const int SyncBoolReq_Elevator0CalledToFloor_4 = 45;
-        private const int SyncBoolReq_Elevator0CalledToFloor_5 = 46;
-        private const int SyncBoolReq_Elevator0CalledToFloor_6 = 47;
-        private const int SyncBoolReq_Elevator0CalledToFloor_7 = 48;
-        private const int SyncBoolReq_Elevator0CalledToFloor_8 = 49;
-        private const int SyncBoolReq_Elevator0CalledToFloor_9 = 50;
-        private const int SyncBoolReq_Elevator0CalledToFloor_10 = 51;
-        private const int SyncBoolReq_Elevator0CalledToFloor_11 = 52;
-        private const int SyncBoolReq_Elevator0CalledToFloor_12 = 53;
-        private const int SyncBoolReq_Elevator0CalledToFloor_13 = 54;
+        private const int SyncBoolReq_Elevator0CalledToFloor_0 = 38;
+        private const int SyncBoolReq_Elevator0CalledToFloor_1 = 39;
+        private const int SyncBoolReq_Elevator0CalledToFloor_2 = 40;
+        private const int SyncBoolReq_Elevator0CalledToFloor_3 = 41;
+        private const int SyncBoolReq_Elevator0CalledToFloor_4 = 42;
+        private const int SyncBoolReq_Elevator0CalledToFloor_5 = 43;
+        private const int SyncBoolReq_Elevator0CalledToFloor_6 = 44;
+        private const int SyncBoolReq_Elevator0CalledToFloor_7 = 45;
+        private const int SyncBoolReq_Elevator0CalledToFloor_8 = 46;
+        private const int SyncBoolReq_Elevator0CalledToFloor_9 = 47;
+        private const int SyncBoolReq_Elevator0CalledToFloor_10 = 48;
+        private const int SyncBoolReq_Elevator0CalledToFloor_11 = 49;
+        private const int SyncBoolReq_Elevator0CalledToFloor_12 = 50;
+        private const int SyncBoolReq_Elevator0CalledToFloor_13 = 51;
         /// <summary>
         /// Sync-data positions for internal elevator 1 buttons
         /// </summary>
-        private const int SyncBoolReq_Elevator1CalledToFloor_0 = 55;
-        private const int SyncBoolReq_Elevator1CalledToFloor_1 = 56;
-        private const int SyncBoolReq_Elevator1CalledToFloor_2 = 57;
-        private const int SyncBoolReq_Elevator1CalledToFloor_3 = 58;
-        private const int SyncBoolReq_Elevator1CalledToFloor_4 = 59;
-        private const int SyncBoolReq_Elevator1CalledToFloor_5 = 60;
-        private const int SyncBoolReq_Elevator1CalledToFloor_6 = 61;
-        private const int SyncBoolReq_Elevator1CalledToFloor_7 = 62;
-        private const int SyncBoolReq_Elevator1CalledToFloor_8 = 63;
-        private const int SyncBoolReq_Elevator1CalledToFloor_9 = 64;
-        private const int SyncBoolReq_Elevator1CalledToFloor_10 = 65;
-        private const int SyncBoolReq_Elevator1CalledToFloor_11 = 66;
-        private const int SyncBoolReq_Elevator1CalledToFloor_12 = 67;
-        private const int SyncBoolReq_Elevator1CalledToFloor_13 = 68;
+        private const int SyncBoolReq_Elevator1CalledToFloor_0 = 52;
+        private const int SyncBoolReq_Elevator1CalledToFloor_1 = 53;
+        private const int SyncBoolReq_Elevator1CalledToFloor_2 = 54;
+        private const int SyncBoolReq_Elevator1CalledToFloor_3 = 55;
+        private const int SyncBoolReq_Elevator1CalledToFloor_4 = 56;
+        private const int SyncBoolReq_Elevator1CalledToFloor_5 = 57;
+        private const int SyncBoolReq_Elevator1CalledToFloor_6 = 58;
+        private const int SyncBoolReq_Elevator1CalledToFloor_7 = 59;
+        private const int SyncBoolReq_Elevator1CalledToFloor_8 = 60;
+        private const int SyncBoolReq_Elevator1CalledToFloor_9 = 61;
+        private const int SyncBoolReq_Elevator1CalledToFloor_10 = 62;
+        private const int SyncBoolReq_Elevator1CalledToFloor_11 = 63;
+        private const int SyncBoolReq_Elevator1CalledToFloor_12 = 64;
+        private const int SyncBoolReq_Elevator1CalledToFloor_13 = 65;
         /// <summary>
         /// Sync-data positions for internal elevator 2 buttons
         /// </summary>
-        private const int SyncBoolReq_Elevator2CalledToFloor_0 = 69;
-        private const int SyncBoolReq_Elevator2CalledToFloor_1 = 70;
-        private const int SyncBoolReq_Elevator2CalledToFloor_2 = 71;
-        private const int SyncBoolReq_Elevator2CalledToFloor_3 = 72;
-        private const int SyncBoolReq_Elevator2CalledToFloor_4 = 73;
-        private const int SyncBoolReq_Elevator2CalledToFloor_5 = 74;
-        private const int SyncBoolReq_Elevator2CalledToFloor_6 = 75;
-        private const int SyncBoolReq_Elevator2CalledToFloor_7 = 76;
-        private const int SyncBoolReq_Elevator2CalledToFloor_8 = 77;
-        private const int SyncBoolReq_Elevator2CalledToFloor_9 = 78;
-        private const int SyncBoolReq_Elevator2CalledToFloor_10 = 79;
-        private const int SyncBoolReq_Elevator2CalledToFloor_11 = 80;
-        private const int SyncBoolReq_Elevator2CalledToFloor_12 = 81;
-        private const int SyncBoolReq_Elevator2CalledToFloor_13 = 82;
+        private const int SyncBoolReq_Elevator2CalledToFloor_0 = 66;
+        private const int SyncBoolReq_Elevator2CalledToFloor_1 = 67;
+        private const int SyncBoolReq_Elevator2CalledToFloor_2 = 68;
+        private const int SyncBoolReq_Elevator2CalledToFloor_3 = 69;
+        private const int SyncBoolReq_Elevator2CalledToFloor_4 = 70;
+        private const int SyncBoolReq_Elevator2CalledToFloor_5 = 71;
+        private const int SyncBoolReq_Elevator2CalledToFloor_6 = 72;
+        private const int SyncBoolReq_Elevator2CalledToFloor_7 = 73;
+        private const int SyncBoolReq_Elevator2CalledToFloor_8 = 74;
+        private const int SyncBoolReq_Elevator2CalledToFloor_9 = 75;
+        private const int SyncBoolReq_Elevator2CalledToFloor_10 = 76;
+        private const int SyncBoolReq_Elevator2CalledToFloor_11 = 77;
+        private const int SyncBoolReq_Elevator2CalledToFloor_12 = 78;
+        private const int SyncBoolReq_Elevator2CalledToFloor_13 = 79;
         /// <summary>
-        /// State of the elevator bell
+        /// Last few state bools
         /// </summary>
-        private const int SyncBoolReq_BellOn = 83;
+        private const int SyncBool_Initialized = 80;
+        private const int SyncBool_Elevator0working = 81;
+        private const int SyncBool_Elevator1working = 82;
+        private const int SyncBool_Elevator2working = 83;
 
         #endregion ENUM_SYNCBOOL
         #region ENUM_DIRECTSYNCBOOL
@@ -1204,118 +1204,118 @@ namespace WindowsFormsApp1
         ///  - (0U == (_syncData2 & (1U << (SyncBool_AddressUint
         /// </summary>
         ///         
-        private const ulong SyncBool_MaskUlong_Initialized = (1UL);
-        private const int SyncBool_AddressUlong_ElevatorXworking = 1;
-        private const ulong SyncBool_MaskUlong_Elevator0working = (1UL << 1);
-        private const ulong SyncBool_MaskUlong_Elevator1working = (1UL << 2);
-        private const ulong SyncBool_MaskUlong_Elevator2working = (1UL << 3);
-        private const int SyncBool_AddressUlong_ElevatorXopen = 4;
-        private const ulong SyncBool_MaskUlong_Elevator0open = (1UL << 4);
-        private const ulong SyncBool_MaskUlong_Elevator1open = (1UL << 5);
-        private const ulong SyncBool_MaskUlong_Elevator2open = (1UL << 6);
-        private const int SyncBool_AddressUlong_ElevatorXidle = 7;
-        private const ulong SyncBool_MaskUlong_Elevator0idle = (1UL << 7);
-        private const ulong SyncBool_MaskUlong_Elevator1idle = (1UL << 8);
-        private const ulong SyncBool_MaskUlong_Elevator2idle = (1UL << 9);
-        private const int SyncBool_AddressUlong_ElevatorXgoingUp = 10;
-        private const ulong SyncBool_MaskUlong_Elevator0goingUp = (1UL << 10);
-        private const ulong SyncBool_MaskUlong_Elevator1goingUp = (1UL << 11);
-        private const ulong SyncBool_MaskUlong_Elevator2goingUp = (1UL << 12);
+        private const ulong SyncBoolReq_MaskUlong_BellOn = (1UL);
+        private const int SyncBool_AddressUlong_ElevatorXopen = 1;
+        private const ulong SyncBool_MaskUlong_Elevator0open = (1UL << 1);
+        private const ulong SyncBool_MaskUlong_Elevator1open = (1UL << 2);
+        private const ulong SyncBool_MaskUlong_Elevator2open = (1UL << 3);
+        private const int SyncBool_AddressUlong_ElevatorXidle = 4;
+        private const ulong SyncBool_MaskUlong_Elevator0idle = (1UL << 4);
+        private const ulong SyncBool_MaskUlong_Elevator1idle = (1UL << 5);
+        private const ulong SyncBool_MaskUlong_Elevator2idle = (1UL << 6);
+        private const int SyncBool_AddressUlong_ElevatorXgoingUp = 7;
+        private const ulong SyncBool_MaskUlong_Elevator0goingUp = (1UL << 7);
+        private const ulong SyncBool_MaskUlong_Elevator1goingUp = (1UL << 8);
+        private const ulong SyncBool_MaskUlong_Elevator2goingUp = (1UL << 9);
         /// <summary>     
         /// Sync-data positions for elevator call up
         /// </summary>            
-        private const int SyncBoolReq_AddressUlong_ElevatorCalledUp = 13;
-        /*private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_0 = (1UL << 13);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_1 = (1UL << 14);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_2 = (1UL << 15);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_3 = (1UL << 16);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_4 = (1UL << 17);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_5 = (1UL << 18);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_6 = (1UL << 19);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_7 = (1UL << 20);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_8 = (1UL << 21);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_9 = (1UL << 22);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_10 = (1UL << 23);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_11 = (1UL << 24);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_12 = (1UL << 25);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_13 = (1UL << 26);*/
+        private const int SyncBoolReq_AddressUlong_ElevatorCalledUp = 10;
+        /*private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_0 = (1UL << 10);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_1 = (1UL << 11);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_2 = (1UL << 12);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_3 = (1UL << 13);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_4 = (1UL << 14);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_5 = (1UL << 15);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_6 = (1UL << 16);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_7 = (1UL 17);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_8 = (1UL << 18);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_9 = (1UL << 19);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_10 = (1UL << 20);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_11 = (1UL << 21);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_12 = (1UL << 22);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledUp_13 = (1UL << 23);*/
         
         /// <summary>     
         /// Sync-data positions for elevator call down
         /// </summary>     
-        private const int SyncBoolReq_AddressUlong_ElevatorCalledDown = 27;
-        /*private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_0 = (1UL << 27);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_1 = (1UL << 28);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_2 = (1UL << 29);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_3 = (1UL << 30);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_4 = (1UL << 31);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_5 = (1UL << 32);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_6 = (1UL << 33);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_7 = (1UL << 34);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_8 = (1UL << 35);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_9 = (1UL << 36);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_10 = (1UL << 37);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_11 = (1UL << 38);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_12 = (1UL << 39);
-        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_13 = (1UL << 40);*/
+        private const int SyncBoolReq_AddressUlong_ElevatorCalledDown = 24;
+        /*private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_0 = (1UL << 24);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_1 = (1UL << 25);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_2 = (1UL << 26);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_3 = (1UL << 27);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_4 = (1UL << 28);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_5 = (1UL << 29);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_6 = (1UL << 30);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_7 = (1UL << 31);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_8 = (1UL << 32);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_9 = (1UL << 33);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_10 = (1UL << 34);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_11 = (1UL << 35);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_12 = (1UL << 36);
+        private const ulong SyncBoolReq_MaskUlong_ElevatorCalledDown_13 = (1UL << 37);*/
 
         /// <summary>     
         /// Sync-data positions for internal elevator 0
         /// ******THIS CANNOT BE USED****** It spans both the Ulong and Uint, use getSyncValues instead
         /// </summary>    
-        /*private const int SyncBoolReq_AddressUlong_Elevator0CalledToFloor = 41;
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_0 = (1UL << 41);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_1 = (1UL << 42);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_2 = (1UL << 43);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_3 = (1UL << 44);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_4 = (1UL << 45);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_5 = (1UL << 46);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_6 = (1UL << 47);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_7 = (1UL << 48);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_8 = (1UL << 49);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_9 = (1UL << 50);
-        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_10 = (1UL << 51);
-        private const uint SyncBoolReq_MaskUint_Elevator0CalledToFloor_11 = (1U);
-        private const uint SyncBoolReq_MaskUint_Elevator0CalledToFloor_12 = (1U << 1);
-        private const uint SyncBoolReq_MaskUint_Elevator0CalledToFloor_13 = (1U << 2);*/
+        private const int SyncBoolReq_AddressUlong_Elevator0CalledToFloor = 38;
+        /*private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_0 = (1UL << 38);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_1 = (1UL << 39);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_2 = (1UL << 40);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_3 = (1UL << 41);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_4 = (1UL << 42);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_5 = (1UL << 43);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_6 = (1UL << 44);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_7 = (1UL << 45);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_8 = (1UL << 46);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_9 = (1UL << 47);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_10 = (1UL << 48);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_11 = (1UL << 49);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_12 = (1UL << 50);
+        private const ulong SyncBoolReq_MaskUlong_Elevator0CalledToFloor_13 = (1UL << 51);*/
         /// <summary>     
         /// Sync-data positions for internal elevator 1
         /// </summary>     
-        private const int SyncBoolReq_AddressUint_Elevator1CalledToFloor = 3;
-        /*private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_0 = (1U << 3);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_1 = (1U << 4);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_2 = (1U << 5);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_3 = (1U << 6);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_4 = (1U << 7);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_5 = (1U << 8);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_6 = (1U << 9);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_7 = (1U << 10);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_8 = (1U << 11);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_9 = (1U << 12);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_10 = (1U << 13);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_11 = (1U << 14);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_12 = (1U << 15);
-        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_13 = (1U << 16);*/
+        private const int SyncBoolReq_AddressUint_Elevator1CalledToFloor = 0;
+        /*private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_0 = (1U << 0);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_1 = (1U << 1);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_2 = (1U << 2);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_3 = (1U << 3);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_4 = (1U << 4);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_5 = (1U << 5);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_6 = (1U << 6);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_7 = (1U << 7);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_8 = (1U << 8);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_9 = (1U << 9);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_10 = (1U << 10);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_11 = (1U << 11);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_12 = (1U << 12);
+        private const uint SyncBoolReq_MaskUint_Elevator1CalledToFloor_13 = (1U << 13);*/
         /// <summary>     
         /// Sync-data positions for internal elevator 2
         /// </summary>     
-        private const int SyncBoolReq_AddressUint_Elevator2CalledToFloor = 17;        
-        /*private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_0 = (1U << 17);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_1 = (1U << 18);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_2 = (1U << 19);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_3 = (1U << 20);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_4 = (1U << 21);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_5 = (1U << 22);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_6 = (1U << 23);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_7 = (1U << 24);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_8 = (1U << 25);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_9 = (1U << 26);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_10 = (1U << 27);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_11 = (1U << 28);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_12 = (1U << 29);
-        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_13 = (1U << 30);*/
-
-        private const uint SyncBoolReq_MaskUint_BellOn = (1U << 31);
+        private const int SyncBoolReq_AddressUint_Elevator2CalledToFloor = 14;
+        /*private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_0 = (1U << 14);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_1 = (1U << 15);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_2 = (1U << 16);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_3 = (1U << 17);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_4 = (1U << 18);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_5 = (1U << 19);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_6 = (1U << 20);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_7 = (1U << 21);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_8 = (1U << 22);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_9 = (1U << 23);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_10 = (1U << 24);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_11 = (1U << 25);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_12 = (1U << 26);
+        private const uint SyncBoolReq_MaskUint_Elevator2CalledToFloor_13 = (1U << 27);*/
+        
+        private const uint SyncBool_MaskUint_Initialized = (1U << 28);
+        private const int SyncBool_AddressUlong_ElevatorXworking = 29;
+        private const uint SyncBool_MaskUint_Elevator0working = (1U << 29);
+        private const uint SyncBool_MaskUint_Elevator1working = (1U << 30);
+        private const uint SyncBool_MaskUint_Elevator2working = (1U << 31);
 
         #endregion ENUM_DIRECTSYNCBOOL
         //------------------------------------------------------------------------------------------------------------
@@ -1331,7 +1331,7 @@ namespace WindowsFormsApp1
             Debug.Print("[NetworkController] NetworkingController is now in Start()");
             //NOPE _localPlayer = Networking.LocalPlayer;
             //the first master has to set the constant scene settings
-            if (_localPlayerisMaster && 0UL == (_syncData1 & (SyncBool_MaskUlong_Initialized)))
+            if (_localPlayerisMaster && 0U == (_syncData2 & (SyncBool_MaskUint_Initialized)))
             {
                 _isMaster = true;
                 MASTER_SetConstSceneElevatorStates();
@@ -1440,7 +1440,7 @@ namespace WindowsFormsApp1
             for (int i = 0; i <= 13; i++)
             {
                 //If Elevator0 called to floor i
-                if (GetSyncValue(SyncBoolReq_Elevator0CalledToFloor_0 + i))
+                if (0UL != (_syncData1 & (1UL << (SyncBoolReq_AddressUlong_Elevator0CalledToFloor + i))))
                 {
                     _elevator0FloorTargets_MASTER[i] = true;
                     _elevator0FloorTargets_MASTER_COUNT++;
@@ -2393,9 +2393,9 @@ namespace WindowsFormsApp1
         private void LOCAL_ReadConstSceneElevatorStates()
         {
             Debug.Print("[NetworkController] Setting random elevator states for reception by localPlayer");
-            _elevator0Working = 0UL != (_syncData1 & (SyncBool_MaskUlong_Elevator0working));
-            _elevator1Working = 0UL != (_syncData1 & (SyncBool_MaskUlong_Elevator1working));
-            _elevator2Working = 0UL != (_syncData1 & (SyncBool_MaskUlong_Elevator2working));
+            _elevator0Working = 0U != (_syncData2 & (SyncBool_MaskUint_Elevator0working));
+            _elevator1Working = 0U != (_syncData2 & (SyncBool_MaskUint_Elevator1working));
+            _elevator2Working = 0U != (_syncData2 & (SyncBool_MaskUint_Elevator2working));
             form1.DisplayElevatorBroken(_elevator0Working, _elevator1Working, _elevator2Working);
             //NOPE _elevatorControllerReception._elevator1working = _elevator0Working;
             //NOPE _elevatorControllerReception._elevator2working = _elevator1Working;
@@ -2422,7 +2422,7 @@ namespace WindowsFormsApp1
                 if (time.GetTime() < 1f) //no scene setup before at least 1 second has passed to ensure the update loop has already started
                     return;
                 Debug.Print("[NetworkController] Local setup was started");
-                if (0UL != (_syncData1 & (SyncBool_MaskUlong_Initialized)))
+                if (0U != (_syncData2 & (SyncBool_MaskUint_Initialized)))
                 {
                     LOCAL_ReadConstSceneElevatorStates();
                     _finishedLocalSetup = true;
@@ -2623,7 +2623,7 @@ namespace WindowsFormsApp1
                         _pendingCallElevator1_COUNT_LOCAL_INT--;
 
                         //if NOT elevator1 called to floor X
-                        if (0U == (_syncData1 & (1U << (SyncBoolReq_AddressUint_Elevator1CalledToFloor + floor))))
+                        if (0U == (_syncData2 & (1U << (SyncBoolReq_AddressUint_Elevator1CalledToFloor + floor))))
                         {
                             Debug.Print("Dropped request, SetElevatorInternalButtonState() button " + floor + " after " + (time.GetTime() - _pendingCallElevator1Time_LOCAL_INT[floor]).ToString() + " seconds.");
                             LOCAL_SetElevatorInternalButtonState(0, floor, called: false);
@@ -2640,7 +2640,7 @@ namespace WindowsFormsApp1
                     {
                         _pendingCallElevator0_LOCAL_INT[floor] = false;
                         _pendingCallElevator0_COUNT_LOCAL_INT--;
-                        if (!GetSyncValue(SyncBoolReq_Elevator0CalledToFloor_0 + floor))
+                        if (0UL == (_syncData1 & (1UL << (SyncBoolReq_AddressUlong_Elevator0CalledToFloor + floor))))
                         {
                             Debug.Print("Dropped request, SetElevatorInternalButtonState() button " + floor + " after " + (time.GetTime() - _pendingCallElevator0Time_LOCAL_INT[floor]).ToString() + " seconds.");
                             LOCAL_SetElevatorInternalButtonState(0, floor, called: false);
@@ -2819,7 +2819,8 @@ namespace WindowsFormsApp1
         {
 
             Debug.Print("[NetworkController] Master received client request to set target for elevator " + elevatorNumber + " to floor " + floorNumber);
-            if (elevatorNumber == 0 && !GetSyncValue(SyncBoolReq_Elevator0CalledToFloor_0 + floorNumber))
+            //if elevatorNumber0 AND NOT elevator0 called to floor X
+            if (elevatorNumber == 0 && (0UL == (_syncData1 & (1UL << (SyncBoolReq_AddressUlong_Elevator0CalledToFloor + floorNumber)))))
             {
                 Debug.Print("Internal target was now set.");
                 MASTER_SetSyncValue(SyncBoolReq_Elevator0CalledToFloor_0 + floorNumber, true);


### PR DESCRIPTION
Moved initialised and elevators working to the uint. Now there are no spanning arrays between the uint and ulong.
Have re-optimised Elevator0CalledToFloor.

Also fixed internal buttons resetting.